### PR TITLE
benchmarks/particlefilter: Force CMake to use Python 3

### DIFF
--- a/approx/approx_utilities/benchmarks/patches/particlefilter.patch
+++ b/approx/approx_utilities/benchmarks/patches/particlefilter.patch
@@ -12,7 +12,7 @@ diff -Naur ../original_src/rodinia_3.1/openmp/particlefilter/CMakeLists.txt part
 +set(SRC_FILES "particlefilter.cpp")
 +set(APP_NAME "pFilter")
 +
-+execute_process(COMMAND python ${CMAKE_SOURCE_DIR}/configure.py 
++execute_process(COMMAND python3 ${CMAKE_SOURCE_DIR}/configure.py 
 +    ${CMAKE_SOURCE_DIR}
 +    ${CMAKE_CURRENT_BINARY_DIR} 
 +    ${CMAKE_CURRENT_SOURCE_DIR} ${APP_NAME} ${SRC_FILES}


### PR DESCRIPTION
Hello,

All the other patch files use Python 3 explicitly; this change brings the particle filter build script in line with the others.

Without this change, the build fails on systems where `python` is linked to Python 2 by default.

